### PR TITLE
fix(dropzone): allow to accept */* on web

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-ui-components",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": false,
   "main": "index.js",
   "scripts": {

--- a/src/Dropzone/index.web.js
+++ b/src/Dropzone/index.web.js
@@ -25,8 +25,9 @@ const Dropzone = ({
   accept,
   children,
   onDrop,
+  multiple,
 }) => (
-  <RNDropzone onDrop={onDrop} accept={accept}>
+  <RNDropzone onDrop={onDrop} accept={accept[0] === '*/*' ? null : accept} multiple={multiple}>
     {({ getRootProps, getInputProps }) => (
       <div {...getRootProps()} style={{ ...styles.container, ...StyleSheet.flatten(style || {}) }}>
         <input {...getInputProps()} />
@@ -43,6 +44,7 @@ Dropzone.propTypes = {
   onDrop: PropTypes.func,
   style: StylePropType,
   children: PropTypes.node,
+  multiple: PropTypes.bool,
 };
 
 Dropzone.defaultProps = {
@@ -50,6 +52,7 @@ Dropzone.defaultProps = {
   onDrop: noop,
   style: null,
   children: null,
+  multiple: true,
 };
 
 export default withTheme('Dropzone')(Dropzone);

--- a/src/Helmet/index.web.js
+++ b/src/Helmet/index.web.js
@@ -30,7 +30,7 @@ const parseTags = (children, tags) => {
           tags.meta.push(pick(tag.props, 'name', 'property', 'content'));
           break;
         case 'link':
-          tags.link.push(pick(tag.props, 'rel', 'href'));
+          tags.link.push(pick(tag.props, 'rel', 'href', 'type'));
           break;
         case 'script':
           script = omit(tag.props, 'children');

--- a/src/Icon/index.web.js
+++ b/src/Icon/index.web.js
@@ -4,6 +4,7 @@ import { StyleSheet, Text } from 'react-native';
 import WebFontAwesome from 'react-fontawesome';
 import StylePropType from '../StylePropType';
 import { withTheme } from '../Theme';
+import { Helmet, link } from '../Helmet';
 
 const styles = StyleSheet.create({
   empty: {},
@@ -11,9 +12,18 @@ const styles = StyleSheet.create({
 });
 
 const Icon = ({ name, style, className }) => (
-  <Text className={className} style={[styles.defaults, style]}>
-    <WebFontAwesome name={name} />
-  </Text>
+  <React.Fragment>
+    <Helmet>
+      <link
+        rel="stylesheet"
+        type="text/css"
+        href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      />
+    </Helmet>
+    <Text className={className} style={[styles.defaults, style]}>
+      <WebFontAwesome name={name} />
+    </Text>
+  </React.Fragment>
 );
 
 Icon.propTypes = {


### PR DESCRIPTION
**Summary**

The web version of the component was not accepting */*.

This PR fixes/implements the following **bugs/features**

* [ ] The web/dropzone was not allowing */*
* [ ] Icon was not importing FontAwesome automatically.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Now dropzone can receive `['*/*']` and allows any type of file to be chosen. Also, the Icon component wasn't importing the FontAwesome library when used. Now, we inject the FontAwesome library using Helmet. We still can't automatically import FontAwesome on Expo, so users MUST add that font to assets manually.
