### PR TITLE
fix(link): remove amp invalid attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-ui-components",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": false,
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-ui-components",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": false,
   "main": "index.js",
   "scripts": {

--- a/src/Link/index.web.js
+++ b/src/Link/index.web.js
@@ -84,7 +84,6 @@ const Link = compose(
   }
   return (
     <Wrapper
-      type={type}
       target={blank ? '_blank' : undefined}
       className={`${className} ${type}`}
       href={href}


### PR DESCRIPTION
**Summary**

We were sending type="color" to the DOM and that is an invalid
attribute value for A tags.

This PR fixes/implements the following **bugs/features**

* [x] Remove AMP invalid attributes

Explain the **motivation** for making this change. What existing problem does the pull request solve?

This library should be compliant of Google AMP rules.
