### PR TITLE
fix(autocomplete): use TouchableOpacity in handling click event for autocomplete.item

### DIFF
--- a/src/Autocomplete/Item.js
+++ b/src/Autocomplete/Item.js
@@ -8,6 +8,7 @@ import { withTheme } from '../Theme';
 import { isEmpty, escapeRegExp } from '../utils';
 import createDomStyle from '../createDomStyle';
 import { Helmet, style } from '../Helmet';
+import TouchableOpacity from '../TouchableOpacity';
 
 const styles = StyleSheet.create({
   defaults: {
@@ -74,15 +75,16 @@ const Item = ({
           `}
         </style>
       </Helmet>
-      <Text
-        className={`Autocomplete__Item Autocomplete__Item-${index} ${active ? 'Autocomplete__Item-active' : ''}`}
-        onPress={onItemPress}
-        style={textStyle}
-        numberOfLines={numberOfLines}
-        ellipsizeMode="tail"
-      >
-        {components}
-      </Text>
+      <TouchableOpacity onPress={onItemPress}>
+        <Text
+          className={`Autocomplete__Item Autocomplete__Item-${index} ${active ? 'Autocomplete__Item-active' : ''}`}
+          style={textStyle}
+          numberOfLines={numberOfLines}
+          ellipsizeMode="tail"
+        >
+          {components}
+        </Text>
+      </TouchableOpacity>
     </>
   );
 };


### PR DESCRIPTION
**Summary**

Use `TouchableOpacity` in handling click even for `Autocomplete` item component

This PR fixes/implements the following **bugs/features**

* [X] Use TouchableOpacity to handle click event

**Test plan (required)**

- Use autocomplete widget
- Search something to populate the items
- Click on the edge of one of the items

Before:
![ezgif-6-b47d5f209ff2](https://user-images.githubusercontent.com/54905174/79166915-c0f7c680-7e18-11ea-83ae-e173501e60c8.gif)

After:
![ezgif-6-ecd3bcf37b6b](https://user-images.githubusercontent.com/54905174/79166901-b89f8b80-7e18-11ea-821e-5066e0148563.gif)

**Closing Issues**

Closes https://github.com/CareLuLu/v3-app/issues/987