### PR TITLE
feat(datepicker): add autocomplete prop

### DIFF
--- a/src/Datepicker/index.web.js
+++ b/src/Datepicker/index.web.js
@@ -203,6 +203,7 @@ const Datepicker = (props) => {
     className,
     is24Hour,
     timeIntervals,
+    autoComplete,
   } = props;
 
   let currentFormat = format;
@@ -265,6 +266,7 @@ const Datepicker = (props) => {
         onBlur={onBlur}
         style={currentStyle}
         strictParsing
+        autoComplete={autoComplete}
       />
     </View>
   );
@@ -288,6 +290,7 @@ Datepicker.propTypes = {
   format: PropTypes.string,
   is24Hour: PropTypes.bool,
   timeIntervals: PropTypes.number,
+  autoComplete: PropTypes.string,
 };
 
 Datepicker.defaultProps = {
@@ -308,6 +311,7 @@ Datepicker.defaultProps = {
   format: null,
   is24Hour: false,
   timeIntervals: 15,
+  autoComplete: 'off',
 };
 
 export default withTheme('Datepicker')(Datepicker);


### PR DESCRIPTION
**Summary**

Disable autocomplete on datetime fields

This PR fixes/implements the following **bugs/features**

* [X] Added `autoComplete` prop and set 'off' as default.

**Test plan (required)**

- Use Datetime component or create a ui-form with type=string and format=date-time
- Inspect element and autocomplete should be set to off

<img width="465" alt="Screenshot 2020-06-10 at 8 36 08 AM" src="https://user-images.githubusercontent.com/54905174/84214280-8303df80-aaf5-11ea-9b13-d14a8354223c.png">

**Closing issues**

Closes https://github.com/CareLuLu/v3-app/issues/1082
