### PR TITLE
fix(datepicker): update autocomplete value

### DIFF
--- a/src/Datepicker/index.web.js
+++ b/src/Datepicker/index.web.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet } from 'react-native';
 import noop from 'lodash/noop';
@@ -203,7 +203,6 @@ const Datepicker = (props) => {
     className,
     is24Hour,
     timeIntervals,
-    autoComplete,
   } = props;
 
   let currentFormat = format;
@@ -221,6 +220,8 @@ const Datepicker = (props) => {
     formats,
     format: currentFormat,
   };
+
+  const [autoComplete] = useState(`date-field-${Math.random().toString(36).substring(2, 9)}`);
 
   const [
     onRef,
@@ -290,7 +291,6 @@ Datepicker.propTypes = {
   format: PropTypes.string,
   is24Hour: PropTypes.bool,
   timeIntervals: PropTypes.number,
-  autoComplete: PropTypes.string,
 };
 
 Datepicker.defaultProps = {
@@ -311,7 +311,6 @@ Datepicker.defaultProps = {
   format: null,
   is24Hour: false,
   timeIntervals: 15,
-  autoComplete: 'off',
 };
 
 export default withTheme('Datepicker')(Datepicker);


### PR DESCRIPTION
**Summary**

Set the autocomplete to a different value since `autocomplete="off"` is being ignored by chrome. see https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164

This PR fixes/implements the following **bugs/features**

* [X] Update autocomplete value to disable autocomplete in chrome

**Test plan (required)**

- Use `<Datetime />` component or create a ui-form with type=string and format=date-time
- Inspect element and autocomplete attribute should be set to the following:

<img width="566" alt="Screenshot 2020-06-12 at 11 54 24 PM" src="https://user-images.githubusercontent.com/54905174/84521788-17459080-ad08-11ea-956b-5116f91c7b77.png">

**Closing issues**

Closes https://github.com/CareLuLu/v3-app/issues/1295
