### PR TITLE
fix(package.json): move expo deps to peer and dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,17 +47,17 @@
     "react-art": "17.0.2",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
     "react-native-web": "0.17.5",
-    "react-test-renderer": "17.0.2"
-  },
-  "dependencies": {
+    "react-test-renderer": "17.0.2",
     "@expo/vector-icons": "^12.0.0",
-    "@react-native-community/datetimepicker": "^3.0.1",
-    "@tippy.js/react": "^3.0.0",
     "expo-blur": "^9.0.0",
     "expo-document-picker": "^9.0.1",
     "expo-file-system": "^11.0.0",
     "expo-image-picker": "^10.0.0",
-    "expo-permissions": "^12.0.0",
+    "expo-permissions": "^12.0.0"
+  },
+  "dependencies": {
+    "@react-native-community/datetimepicker": "^3.0.1",
+    "@tippy.js/react": "^3.0.0",
     "fast-deep-equal": "^3.0.0",
     "lodash": "^4.17.21",
     "moment": "^2.24.0",
@@ -78,6 +78,12 @@
   },
   "peerDependencies": {
     "expo": "*",
+    "@expo/vector-icons": "*",
+    "expo-blur": "*",
+    "expo-document-picker": "*",
+    "expo-file-system": "*",
+    "expo-image-picker": "*",
+    "expo-permissions": "*",
     "react": "^16.8.3 || ^17.0.0",
     "react-dom": "^16.8.3 || ^17.0.0",
     "react-native": "*",


### PR DESCRIPTION
Move the expo dependencies as devDependencies and peerDependencies.

The peerDependencies are stripped of their version restrictions to allow
it to work with Expo SDK 43.

Fixes
https://github.com/CareLuLu/react-native-web-ui-components/issues/463

A similar PR may already be submitted!
Please search among the [Pull request](../../pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
